### PR TITLE
Added watchOS 7.0 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "Parma",
     platforms: [
         .macOS("10.15"),
-        .iOS("13.0")
+        .iOS("13.0"),
+        .watchOS("7.0")
     ],
     products: [
         .library(


### PR DESCRIPTION
Hello. First of all thanks for this useful package. I was trying to use this for my watchOS app but ran into errors since the package's several internal parts required a watchOS minimum support of 7.0. I have added watchOS 7.0 as a platform to `Package.swift` and now I can use this package.

![Simulator Screen Shot - Apple Watch Series 6 - 40mm - 2021-02-23 at 15 01 32](https://user-images.githubusercontent.com/34488374/108840899-06178800-75e8-11eb-8b33-93db0b16f893.png)
