### PR TITLE
Escape < and > characters

### DIFF
--- a/Sources/Parma/ParmaCore.swift
+++ b/Sources/Parma/ParmaCore.swift
@@ -63,7 +63,7 @@ class ParmaCore: NSObject {
     let context = ComposingContext()
     
     /// Sanitize input to prevent < and > from causing problems
-    private func escapeContent(_ rawContent: String) -> String {
+    private static func escapeContent(_ rawContent: String) -> String {
         
         enum EscapedCharacters: String, CaseIterable {
             
@@ -95,7 +95,7 @@ class ParmaCore: NSObject {
     
     // MARK: - Initialization
     convenience init(_ markdown: String) throws {
-        let down = Down(markdownString: escapeContent(markdown))
+        let down = Down(markdownString: Self.escapeContent(markdown))
         let xml = try down.toXML()
         self.init(xmlData: Data(xml.utf8))
     }

--- a/Sources/Parma/ParmaCore.swift
+++ b/Sources/Parma/ParmaCore.swift
@@ -62,9 +62,40 @@ class ParmaCore: NSObject {
     /// The context for element composing.
     let context = ComposingContext()
     
+    /// Sanitize input to prevent < and > from causing problems
+    private func escapeContent(_ rawContent: String) -> String {
+        
+        enum EscapedCharacters: String, CaseIterable {
+            
+            case leftAngleBracket = "<",
+                 rightAngleBracket = ">"
+            
+            func replacement() -> String {
+                switch self {
+                case .leftAngleBracket:
+                    return "&lt;"
+                case .rightAngleBracket:
+                    return "&gt;"
+                }
+            }
+            
+            static func escapeString(_ string: String) -> String {
+                var escapedValue = string
+                
+                self.allCases.forEach {
+                    escapedValue = escapedValue.replacingOccurrences(of: $0.rawValue, with: $0.replacement())
+                }
+                
+                return escapedValue
+            }
+        }
+        
+        return EscapedCharacters.escapeString(rawContent)
+    }
+    
     // MARK: - Initialization
     convenience init(_ markdown: String) throws {
-        let down = Down(markdownString: markdown)
+        let down = Down(markdownString: escapeContent(markdown))
         let xml = try down.toXML()
         self.init(xmlData: Data(xml.utf8))
     }


### PR DESCRIPTION
Hello,

Thanks for Parma, it's terrific!

I did discover that because XML is used under the hood, content with < and > causes problems with the output, essentially truncating anything before the first <.

This pull adds a function to escape these characters. An enum is provided to allow easy addition of future escaped characters:

```swift
enum EscapedCharacters: String, CaseIterable {
            
            case leftAngleBracket = "<",
                 rightAngleBracket = ">"
            
            func replacement() -> String {
                switch self {
                case .leftAngleBracket:
                    return "&lt;"
                case .rightAngleBracket:
                    return "&gt;"
                }
            }
            
            static func escapeString(_ string: String) -> String {
                var escapedValue = string
                
                self.allCases.forEach {
                    escapedValue = escapedValue.replacingOccurrences(of: $0.rawValue, with: $0.replacement())
                }
                
                return escapedValue
            }
        }
```

I hope you will find this addition useful, and open to any feedback if you'd prefer this to live elsewhere in the project than `ParmaCore`.