### PR TITLE
Add support for multi-level ordered lists

### DIFF
--- a/Parma.podspec
+++ b/Parma.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Parma'
-  s.version          = '0.2.0'
+  s.version          = '0.3.0'
   s.summary          = 'A SwiftUI view for displaying Markdown with customizable appearances.'
   s.description      = 'Display Markdown using pure SwiftUI components. Taking advantages of ViewBuilder to make custom appearances for Text and View.'
   s.homepage         = 'https://github.com/dasautoooo/Parma'

--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ func headingBlock(level: HeadingLevel?, view: AnyView) -> AnyView
 func paragraphBlock(view: AnyView) -> AnyView
 
 /// Define the style of list item.
+/// - Parameter attributes: Attributes of the list containing the item. Those must be considered for proper item rendering.
+/// - Parameter index: Normalized index of the list item. For exemple, the index of the third item of a one level list would be `[2]` and the second item of a sublist appearing fourth in it's parent list would be `[3, 1]`.
 /// - Parameter view: The view contains view(s) which belong(s) to this item.
-func listItem(view: AnyView) -> AnyView
+func listItem(attributes: ListAttributes, index: [Int], view: AnyView) -> AnyView
 
 /// Define the style of image view.
 /// - Parameter urlString: The url string for this image view.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more examples, please refer to [demo][1] app.
     * Strong
     * Emphasis
     * Code
-            
+
 ### Possibly Support in Future Versions
 * Divider
 * Multi-level ordered list

--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ For more examples, please refer to [demo][1] app.
 * Heading level 1-6
 * Paragraph
 * Multi-level bullet list
+* Multi-level ordered list
+    * Period delimiter
+    * Parenthesis delimiter
 * Image (Needs extra configurations)
 * Inline text
-	* Strong
-	* Emphasis
-	* Code
-			
+    * Strong
+    * Emphasis
+    * Code
+            
 ### Possibly Support in Future Versions
 * Divider
 * Multi-level ordered list

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ For more examples, please refer to [demo][1] app.
 
 ### Possibly Support in Future Versions
 * Divider
-* Multi-level ordered list
 * Block quote
 * Code block
 

--- a/Sample/Shared/ContentView.swift
+++ b/Sample/Shared/ContentView.swift
@@ -88,14 +88,31 @@ struct MyRender: ParmaRenderable {
     }
     
     
-    func listItem(view: AnyView) -> AnyView {
-        let bullet = "•"
+    func listItem(attributes: ListAttributes, index: [Int], view: AnyView) -> AnyView {
+        let delimiter: String
+        switch attributes.delimiter {
+        case .period:
+            delimiter = "."
+        case .parenthesis:
+            delimiter = ")"
+        }
+
+        let separator: String
+        switch attributes.type {
+        case .bullet:
+            separator = index.count % 2 == 1 ? "•" : "◦"
+        case .ordered:
+            separator = index
+                .map({ String($0) })
+                .joined(separator: ".")
+                .appending(delimiter)
+        }
+
         return AnyView(
-            HStack(alignment: .top, spacing: 8) {
-                Text(bullet)
-                view.fixedSize(horizontal: false, vertical: true)
+            HStack(alignment: .top, spacing: 4) {
+                Text(separator)
+                view
             }
-            .padding(.leading, 4)
         )
     }
 }

--- a/Sample/Shared/SampleMarkdown.md
+++ b/Sample/Shared/SampleMarkdown.md
@@ -6,6 +6,13 @@
 
 The Italian poet Attilio Bertolucci (born in a hamlet in the countryside) wrote: "As a capital city it had to have a river. As a little capital it received a stream, which is often dry".
 
+**Contents**
+1. Culture
+    1. Food and cuisine
+    1. People
+        1. Painters and sculptors
+        1. Others
+
 ## Culture
 ### Food and cuisine
 Parma is famous for its food and rich gastronomical tradition: two of its specialties are Parmigiano Reggiano cheese (also produced in Reggio Emilia), and Prosciutto di Parma (Parma ham), both given Protected Designation of Origin status. Parma also claims several stuffed pasta dishes like "tortelli d'erbetta" and "anolini in brodo".

--- a/Sources/Parma/Composer/ComposingContext.swift
+++ b/Sources/Parma/Composer/ComposingContext.swift
@@ -26,6 +26,9 @@ class ComposingContext {
     
     /// The element attributes.
     var attributes = [String : String]()
+
+    /// Attributes required to display list elements
+    var listAttributesStack: [ListAttributes] = []
     
     /// Return the element which wrapped the current element if possible.
     var superElement: Element? {

--- a/Sources/Parma/Composer/ListElementComposer.swift
+++ b/Sources/Parma/Composer/ListElementComposer.swift
@@ -12,13 +12,26 @@ import SwiftUI
 
 class ListElementComposer: BlockElementComposer {
     private var index = [Int]()
-    
+
     func willStart(in context: ComposingContext) {
+        var attributes = ListAttributes.defaultAttributes
+
+        if let typeAttribute = context.attributes["type"], let listType = ListType(rawValue: typeAttribute) {
+            attributes.type = listType
+        }
+
+        if let typeAttribute = context.attributes["delim"], let listDelimiter = ListDelimiter(rawValue: typeAttribute) {
+            attributes.delimiter = listDelimiter
+        }
+
+        context.listAttributesStack.append(attributes)
+
         index.append(context.views.count)
     }
     
     func willStop(in context: ComposingContext) {
         index = index.dropLast()
+        context.listAttributesStack.removeLast()
     }
     
     func view(in context: ComposingContext, render: ParmaRenderable) -> AnyView {
@@ -36,7 +49,7 @@ class ListElementComposer: BlockElementComposer {
         } else if views.count > 1 {
             let count = views.count
             return AnyView(
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(0..<count, id: \.self) { index in
                         views[index]
                     }

--- a/Sources/Parma/Composer/ListItemElementComposer.swift
+++ b/Sources/Parma/Composer/ListItemElementComposer.swift
@@ -24,6 +24,15 @@ class ListItemElementComposer: BlockElementComposer {
     func view(in context: ComposingContext, render: ParmaRenderable) -> AnyView {
         let maxIndex = context.views.count
         let minIndex = index.last!
+        let attributes = context.listAttributesStack.last ?? ListAttributes.defaultAttributes
+        let normalizedIndexes: [Int] = index.enumerated()
+            .map({ (elementIndex, element) in
+                var correctedElement = element
+                if elementIndex > 0 {
+                    correctedElement = element - (index[elementIndex - 1] + 1)
+                }
+                return correctedElement + 1
+            })
         
         // Get every view inside this element scope
         let views = Array(context.views[minIndex..<maxIndex])
@@ -32,18 +41,18 @@ class ListItemElementComposer: BlockElementComposer {
         context.views = context.views.dropLast(maxIndex-minIndex)
 
         if views.count == 1, let view = views.first {
-            return render.listItem(view: view)
+            return render.listItem(attributes: attributes, index: normalizedIndexes, view: view)
         } else if views.count > 1 {
             let count = views.count
-            return render.listItem(view: AnyView(
-                VStack(alignment: .leading) {
+            return render.listItem(attributes: attributes, index: normalizedIndexes, view: AnyView(
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(0..<count, id: \.self) { index in
                         views[index]
                     }
                 }
             ))
         } else {
-            return render.listItem(view: AnyView(EmptyView()))
+            return render.listItem(attributes: attributes, index: normalizedIndexes, view: AnyView(EmptyView()))
         }
     }
 }

--- a/Sources/Parma/Element/ListAttributes.swift
+++ b/Sources/Parma/Element/ListAttributes.swift
@@ -1,0 +1,21 @@
+//
+//  ListAttributes.swift
+//  Parma
+//
+//  Created by Antoine Lamy on 5/13/21.
+//
+//  Copyright (c) 2020 Leonard Chan <wxclx98@gmail.com>
+//
+//  MIT license, see LICENSE file for details
+
+import Foundation
+
+/// Attributes used to display a list element.
+public struct ListAttributes {
+    var type: ListType
+    var delimiter: ListDelimiter
+
+    static var defaultAttributes: ListAttributes {
+        ListAttributes(type: .bullet, delimiter: .period)
+    }
+}

--- a/Sources/Parma/Element/ListAttributes.swift
+++ b/Sources/Parma/Element/ListAttributes.swift
@@ -12,8 +12,8 @@ import Foundation
 
 /// Attributes used to display a list element.
 public struct ListAttributes {
-    var type: ListType
-    var delimiter: ListDelimiter
+    public internal(set) var type: ListType
+    public internal(set) var delimiter: ListDelimiter
 
     static var defaultAttributes: ListAttributes {
         ListAttributes(type: .bullet, delimiter: .period)

--- a/Sources/Parma/Element/ListAttributes.swift
+++ b/Sources/Parma/Element/ListAttributes.swift
@@ -12,7 +12,26 @@ import Foundation
 
 /// Attributes used to display a list element.
 public struct ListAttributes {
+    /// Type of the list, can either be ordered or non-ordered (bullet)
     public internal(set) var type: ListType
+
+    /**
+     Type of delimiter to use in the case of an ordered list.
+
+     A dot list delimiter should produce a list like:
+     ~~~
+        1. Item 1
+        2. Item 2
+        3. Item 3
+     ~~~
+
+     While a parenthesis list delimiter should produce a list like:
+     ~~~
+        1) Item 1
+        2) Item 2
+        3) Item 3
+     ~~~
+     */
     public internal(set) var delimiter: ListDelimiter
 
     static var defaultAttributes: ListAttributes {

--- a/Sources/Parma/Element/ListDelimiter.swift
+++ b/Sources/Parma/Element/ListDelimiter.swift
@@ -1,0 +1,17 @@
+//
+//  ListDelimiter.swift
+//  Parma
+//
+//  Created by Antoine Lamy on 5/13/21.
+//
+//  Copyright (c) 2020 Leonard Chan <wxclx98@gmail.com>
+//
+//  MIT license, see LICENSE file for details
+
+import Foundation
+
+/// The types for markdown ordered list delimiters.
+public enum ListDelimiter: String {
+    case period = "period"
+    case parenthesis = "paren"
+}

--- a/Sources/Parma/Render/ParmaRenderable.swift
+++ b/Sources/Parma/Render/ParmaRenderable.swift
@@ -56,7 +56,7 @@ public protocol ParmaRenderable {
     
     /// Define the style of list item.
     /// - Parameter view: The view contains view(s) which belong(s) to this item.
-    func listItem(view: AnyView) -> AnyView
+    func listItem(attributes: ListAttributes, index: [Int], view: AnyView) -> AnyView
     
     /// Define the style of image view.
     /// - Parameter urlString: The url string for this image view.
@@ -109,11 +109,29 @@ extension ParmaRenderable {
         AnyView(view.fixedSize(horizontal: false, vertical: true).padding(.bottom, 8))
     }
     
-    public func listItem(view: AnyView) -> AnyView {
-        let bullet = "•"
+    public func listItem(attributes: ListAttributes, index: [Int], view: AnyView) -> AnyView {
+        let delimiter: String
+        switch attributes.delimiter {
+        case .period:
+            delimiter = "."
+        case .parenthesis:
+            delimiter = ")"
+        }
+
+        let separator: String
+        switch attributes.type {
+        case .bullet:
+            separator = index.count % 2 == 1 ? "•" : "◦"
+        case .ordered:
+            separator = index
+                .map({ String($0) })
+                .joined(separator: ".")
+                .appending(delimiter)
+        }
+
         return AnyView(
             HStack(alignment: .top, spacing: 4) {
-                Text(bullet)
+                Text(separator)
                 view
             }
         )

--- a/Sources/Parma/Render/ParmaRenderable.swift
+++ b/Sources/Parma/Render/ParmaRenderable.swift
@@ -55,6 +55,8 @@ public protocol ParmaRenderable {
     func paragraphBlock(view: AnyView) -> AnyView
     
     /// Define the style of list item.
+    /// - Parameter attributes: Attributes of the list containing the item. Those must be considered for proper item rendering.
+    /// - Parameter index: Normalized index of the list item. For exemple, the index of the third item of a one level list would be `[2]` and the second item of a sublist appearing fourth in it's parent list would be `[3, 1]`.
     /// - Parameter view: The view contains view(s) which belong(s) to this item.
     func listItem(attributes: ListAttributes, index: [Int], view: AnyView) -> AnyView
     


### PR DESCRIPTION
Add support for multi-level ordered lists supporting two types of delimiters: parenthesis and periods. 

It also support mix-and-matching delimiters and list styles. As an exemple, the following markdown:

```markdown
1) Item 1
1) Item 2
1) Item 3
   1. Item 3a
      * Item 3a1
      * Item 3a2
   1. Item 3b
1) Item 4
1) Item 5
   1. Item 5a
   1. Item 5b
```

Would produce the following result with the default `ParmaRenderable`:
![Screen Shot 2021-05-13 at 5 38 48 PM](https://user-images.githubusercontent.com/291573/118191362-7200d400-b412-11eb-914d-a0083496026b.png)

*Notes*
- The default bullet list style has been updated to switch between `•` and `◦` for better readability
![Screen Shot 2021-05-13 at 5 53 43 PM](https://user-images.githubusercontent.com/291573/118192601-63b3b780-b414-11eb-8450-47c40f2e9684.png)

- Fixes the additional spacing for multi-level lists when entering a deeper level
![Screen Shot 2021-05-13 at 5 52 35 PM](https://user-images.githubusercontent.com/291573/118192611-67dfd500-b414-11eb-9828-460aee50f5d7.png)
