### PR TITLE
Add ability to render custom view for links

### DIFF
--- a/Sources/Parma/Composer/LinkElementComposer.swift
+++ b/Sources/Parma/Composer/LinkElementComposer.swift
@@ -10,18 +10,29 @@
 
 import SwiftUI
 
-class LinkElementComposer: InlineElementComposer {
-    var destination: String?
-    
+class LinkElementComposer: BlockElementComposer {
+    private var startIndex: Int = 0
+    private var destination: String = ""
+
     func willStart(in context: ComposingContext) {
-        destination = context.attributes["destination"]
+        startIndex = context.views.count
+        destination = context.attributes["destination"] ?? ""
     }
-    
+
     func willStop(in context: ComposingContext) {
-        destination = nil
+        destination = ""
+        startIndex = 0
     }
-    
-    func text(in context: ComposingContext, render: ParmaRenderable) -> Text {
-        return render.link(textView: context.concatenatedText, destination: destination)
+
+    func view(in context: ComposingContext, render: ParmaRenderable) -> AnyView {
+        if startIndex == context.views.count {
+            // No alt text
+            return render.linkView(with: destination, altTextView: nil)
+        } else {
+            // Has alt text
+            let altTextView = context.views.last
+            context.views = context.views.dropLast()
+            return render.linkView(with: destination, altTextView: altTextView)
+        }
     }
 }

--- a/Sources/Parma/Element/Element.swift
+++ b/Sources/Parma/Element/Element.swift
@@ -17,7 +17,7 @@ enum Element: Hashable {
     /// If the specific element works as inline.
     var isInline: Bool {
         switch self {
-        case .text, .strong, .emphasis, .link, .code:
+        case .text, .strong, .emphasis, .code:
             return true
         default:
             return false

--- a/Sources/Parma/ParmaCore.swift
+++ b/Sources/Parma/ParmaCore.swift
@@ -82,7 +82,6 @@ class ParmaCore: NSObject {
             .text : plaintTextComposer,
             .strong : strongElementComposer,
             .emphasis : emphasisElementComposer,
-            .link : linkElementComposer,
             .code : codeElementComposer,
         ]
         blockComposers =
@@ -90,6 +89,7 @@ class ParmaCore: NSObject {
             .paragraph : paragraphElementComposer,
             .heading : headingElementComposer,
             .image : imageElementComposer,
+            .link : linkElementComposer,
             .list : listElementComposer,
             .item : listItemElementComposer,
             .unknown : unknownElementComposer

--- a/Sources/Parma/Render/ParmaRenderable.swift
+++ b/Sources/Parma/Render/ParmaRenderable.swift
@@ -34,11 +34,10 @@ public protocol ParmaRenderable {
     /// - Parameter textView: The textView generated from captured emphasis string.
     func emphasis(textView: Text) -> Text
     
-    /// Define the link text style.
-    /// - Parameters:
-    ///   - textView: The textView generated from captured link string.
-    ///   - destination: The destination of the link.
-    func link(textView: Text, destination: String?) -> Text
+    /// Define the style of link view.
+    /// - Parameter urlString: The url string for the link destination.
+    /// - Parameter altTextView: The view contains link text.
+    func linkView(with urlString: String, altTextView: AnyView?) -> AnyView
     
     /// Define the code text style.
     /// - Parameter text: The text string captured from code.
@@ -80,8 +79,12 @@ extension ParmaRenderable {
         textView.italic()
     }
     
-    public func link(textView: Text, destination: String?) -> Text {
-        return textView
+    public func linkView(with urlString: String, altTextView: AnyView?) -> AnyView {
+        if urlString.isEmpty {
+            return altTextView ?? AnyView(EmptyView())
+        } else {
+            return AnyView(Text(urlString))
+        }
     }
     
     public func code(_ text: String) -> Text {


### PR DESCRIPTION
I based the custom view implementation on the `ImageElementComposer` logic so we can now provide `AnyView` to render a link instead of plain text.