### PR TITLE
yvl: leverage native SwiftUI link support

### DIFF
--- a/Sources/Parma/ParmaCore.swift
+++ b/Sources/Parma/ParmaCore.swift
@@ -157,6 +157,11 @@ extension ParmaCore: XMLParserDelegate {
     func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         let element = Element.element(elementName)
         
+        linkElementComposer.destination.map {
+            // Update foundCharacters with an embedded link to leverage SwiftUI handle it
+            context.foundCharacters = "[\(context.foundCharacters)](\($0))"
+        }
+        
         if element.isInline {
             if let text = inlineComposers[element]?.text(in: context, render: render) {
                 if let superEl = context.superElement, superEl.isInline {

--- a/Sources/Parma/Render/ParmaRenderable.swift
+++ b/Sources/Parma/Render/ParmaRenderable.swift
@@ -69,7 +69,7 @@ public protocol ParmaRenderable {
 // MARK: - Default render style
 extension ParmaRenderable {
     public func plainText(_ text: String) -> Text {
-        Text(text)
+        Text(.init(text))
     }
     
     public func strong(textView: Text) -> Text {


### PR DESCRIPTION
As there is no way to use the onTapGesture I found a way to leverage the native SwiftUI link rendering in a Text component.

    linkElementComposer.destination.map {
       // Update foundCharacters with an embedded link to leverage SwiftUI handle it
      context.foundCharacters = "[\(context.foundCharacters)](\($0))"
   }
We re-build the link so the Text SwiftUI component renders it as a link and also reacts to it by opening an external browser with the provided url